### PR TITLE
Add dynamic mission progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 1. Instalé y generé la estructura básica del bot
 2. Diseño básico de la base de datos
 3. Implementada lógica inicial de misiones y recompensas
+4. Añadido soporte para misiones con objetivos y recompensas dinámicas
 
-##  Tarea 
-Agregar más tipos de misiones y recompensas dinámicas
+##  Tarea
+Implementar un sistema de notificaciones para avisar a los usuarios cuando una misión esté por expirar
 
 (Definir nuevas reglas para misiones y cómo se calculan las recompensas)
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -12,18 +12,29 @@ from .database import (
     assign_mission,
     get_active_missions,
     complete_mission,
+    update_mission_progress,
+    calculate_reward,
     remove_expired_missions,
 )
 
 bot = Bot(token=settings.bot_token)
 dp = Dispatcher()
 
+
 @dp.message(Command("start"))
 async def start_handler(message: Message):
     user = get_or_create_user(message.from_user.id)
     if not get_active_missions(user.id):
-        assign_mission(user.id, "Env\u00eda un mensaje en el canal", 10, days_valid=1)
+        assign_mission(
+            user.id,
+            "Env\u00eda un mensaje en el canal",
+            2,
+            days_valid=1,
+            mission_type="message",
+            goal=5,
+        )
     await message.answer(f"Bienvenido al bot! Nivel actual: {user.level}")
+
 
 @dp.message(Command("user"))
 async def user_status(message: Message):
@@ -35,7 +46,10 @@ async def user_status(message: Message):
         await message.answer("Uso: /user <id>")
         return
     user = get_or_create_user(target_id)
-    await message.answer(f"Usuario {target_id}: nivel {user.level}, puntos {user.points}")
+    await message.answer(
+        f"Usuario {target_id}: nivel {user.level}, puntos {user.points}"
+    )
+
 
 @dp.message(Command("reset"))
 async def reset_user(message: Message):
@@ -55,8 +69,31 @@ async def missions_list(message: Message):
     if not missions:
         await message.answer("No tienes misiones activas")
         return
-    text_lines = [f"ID {m.id}: {m.description} (+{m.points} puntos)" for m in missions]
-    await message.answer("\n".join(text_lines) + f"\nPuntos: {user.points} Nivel: {user.level}")
+    text_lines = [
+        f"ID {m.id}: {m.description} [{m.progress}/{m.goal}] (+{calculate_reward(m)} puntos)"
+        for m in missions
+    ]
+    await message.answer(
+        "\n".join(text_lines) + f"\nPuntos: {user.points} Nivel: {user.level}"
+    )
+
+
+@dp.message(Command("progress"))
+async def progress_command(message: Message):
+    try:
+        mission_id = int(message.text.split(maxsplit=2)[1])
+    except (IndexError, ValueError):
+        await message.answer("Uso: /progress <id_mision>")
+        return
+    mission = update_mission_progress(message.from_user.id, mission_id)
+    if not mission:
+        await message.answer("Misi\u00f3n no v\u00e1lida")
+        return
+    if mission.progress >= mission.goal:
+        reward = calculate_reward(mission)
+        await message.answer(f"Misi\u00f3n completada! Ganaste {reward} puntos")
+    else:
+        await message.answer(f"Progreso actualizado: {mission.progress}/{mission.goal}")
 
 
 @dp.message(Command("complete"))
@@ -70,7 +107,8 @@ async def complete_command(message: Message):
     if not mission:
         await message.answer("Misi\u00f3n no v\u00e1lida")
         return
-    await message.answer(f"Misi\u00f3n completada! Ganaste {mission.points} puntos")
+    reward = calculate_reward(mission)
+    await message.answer(f"Misi\u00f3n completada! Ganaste {reward} puntos")
 
 
 async def scheduler():
@@ -79,9 +117,11 @@ async def scheduler():
         remove_expired_missions()
         await asyncio.sleep(3600)
 
+
 async def main():
     asyncio.create_task(scheduler())
     await dp.start_polling(bot)
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- support mission types, goals and dynamic rewards
- track mission progress and reward on completion
- add `/progress` command to increment a mission
- display progress in `/missions` list
- update README progress and next task

## Testing
- `python3 -m py_compile bot/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685015e7923c83299372c48c680faf51