### PR TITLE
Implement mission expiry notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 2. Diseño básico de la base de datos
 3. Implementada lógica inicial de misiones y recompensas
 4. Añadido soporte para misiones con objetivos y recompensas dinámicas
+5. Sistema de notificaciones de expiración y nuevas reglas de recompensas
 
 ##  Tarea
-Implementar un sistema de notificaciones para avisar a los usuarios cuando una misión esté por expirar
-
-(Definir nuevas reglas para misiones y cómo se calculan las recompensas)
+Implementar misiones diarias que se asignen automáticamente a todos los usuarios
+(Definir la lógica para generarlas y guardarlas en la base de datos)
 
 Una vez terminaba tu tarea y verificado que funciona y que responde  como debería   procede a:
 -Actualizar el nombre de la tarea (en Codex) con algo que describa este paso

--- a/bot/main.py
+++ b/bot/main.py
@@ -15,6 +15,8 @@ from .database import (
     update_mission_progress,
     calculate_reward,
     remove_expired_missions,
+    get_missions_near_expiry,
+    mark_warning_sent,
 )
 
 bot = Bot(token=settings.bot_token)
@@ -112,9 +114,16 @@ async def complete_command(message: Message):
 
 
 async def scheduler():
-    """Background task to clean expired missions."""
+    """Background task to clean expired missions and warn users."""
     while True:
         remove_expired_missions()
+        missions = get_missions_near_expiry(24)
+        for m in missions:
+            await bot.send_message(
+                m.user_id,
+                f"La misi\u00f3n '{m.description}' expirar\u00e1 pronto",
+            )
+            mark_warning_sent(m.id)
         await asyncio.sleep(3600)
 
 


### PR DESCRIPTION
## Summary
- add `warning_sent` flag for missions
- compute rewards based on mission type
- notify users when missions are close to expiring
- document new progress and next task

## Testing
- `python3 -m py_compile bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68501873d16483298e343826540aded2