### PR TITLE
Implement daily mission auto assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 3. Implementada lógica inicial de misiones y recompensas
 4. Añadido soporte para misiones con objetivos y recompensas dinámicas
 5. Sistema de notificaciones de expiración y nuevas reglas de recompensas
+6. Misiones diarias asignadas automáticamente a todos los usuarios
 
 ##  Tarea
 Implementar misiones diarias que se asignen automáticamente a todos los usuarios
@@ -33,4 +34,5 @@ Una vez terminaba tu tarea y verificado que funciona y que responde  como deber�
 (en el número siguiente pon una descripción que se ajuste a lo que hiciste)
 
 ## Tarea
-(describe el siguiente paso lógico para el desarrollo de un sistema como este, da detalles de ser necesario seguir con algún archivo en específico algún campo o alguna tabla)
+Permitir a los administradores crear misiones personalizadas desde el bot, definiendo descripción, puntos y duración
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -17,6 +17,7 @@ from .database import (
     remove_expired_missions,
     get_missions_near_expiry,
     mark_warning_sent,
+    assign_daily_missions,
 )
 
 bot = Bot(token=settings.bot_token)
@@ -127,8 +128,24 @@ async def scheduler():
         await asyncio.sleep(3600)
 
 
+async def daily_mission_scheduler():
+    """Assign daily missions to all users once per day."""
+    last_day = datetime.utcnow().date()
+    while True:
+        current_day = datetime.utcnow().date()
+        if current_day != last_day:
+            assign_daily_missions(
+                "Misi\u00f3n diaria: env\u00eda 3 mensajes",
+                points=5,
+                goal=3,
+            )
+            last_day = current_day
+        await asyncio.sleep(3600)
+
+
 async def main():
     asyncio.create_task(scheduler())
+    asyncio.create_task(daily_mission_scheduler())
     await dp.start_polling(bot)
 
 


### PR DESCRIPTION
## Summary
- add `created_at` field and daily mission utilities
- assign daily missions once per day in a new scheduler
- document the new progress and future task in `README.md`

## Testing
- `python -m py_compile` on all modules

------
https://chatgpt.com/codex/tasks/task_e_68501a28757c8329a38aa8e3c341ddd9