### PR TITLE
Add admin mission creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 4. Añadido soporte para misiones con objetivos y recompensas dinámicas
 5. Sistema de notificaciones de expiración y nuevas reglas de recompensas
 6. Misiones diarias asignadas automáticamente a todos los usuarios
+7. Misiones personalizadas creadas por administradores desde el bot
 
 ##  Tarea
-Implementar misiones diarias que se asignen automáticamente a todos los usuarios
-(Definir la lógica para generarlas y guardarlas en la base de datos)
+Permitir a los administradores crear misiones personalizadas desde el bot, definiendo descripción, puntos y duración
 
 Una vez terminaba tu tarea y verificado que funciona y que responde  como debería   procede a:
 -Actualizar el nombre de la tarea (en Codex) con algo que describa este paso
@@ -34,5 +34,5 @@ Una vez terminaba tu tarea y verificado que funciona y que responde  como deber�
 (en el número siguiente pon una descripción que se ajuste a lo que hiciste)
 
 ## Tarea
-Permitir a los administradores crear misiones personalizadas desde el bot, definiendo descripción, puntos y duración
+Implementar un sistema de ranking de usuarios basado en puntos acumulados
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,11 +1,18 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dotenv import load_dotenv
 import os
 
 load_dotenv()
 
+
 @dataclass
 class Settings:
-    bot_token: str = os.getenv('BOT_TOKEN', '')
+    bot_token: str = os.getenv("BOT_TOKEN", "")
+    admin_ids: list[int] = field(
+        default_factory=lambda: [
+            int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x
+        ]
+    )
+
 
 settings = Settings()

--- a/bot/main.py
+++ b/bot/main.py
@@ -114,6 +114,27 @@ async def complete_command(message: Message):
     await message.answer(f"Misi\u00f3n completada! Ganaste {reward} puntos")
 
 
+@dp.message(Command("createmission"))
+async def create_mission(message: Message):
+    """Allow admins to create custom missions for a user."""
+    if message.from_user.id not in settings.admin_ids:
+        await message.answer("No autorizado")
+        return
+    try:
+        data = message.text.split(maxsplit=1)[1]
+        user_id_str, desc, points_str, days_str = [
+            part.strip() for part in data.split("|")
+        ]
+        user_id = int(user_id_str)
+        points = int(points_str)
+        days = int(days_str)
+    except Exception:
+        await message.answer("Uso: /createmission user_id|descripcion|puntos|dias")
+        return
+    assign_mission(user_id, desc, points, days_valid=days)
+    await message.answer("Misi\u00f3n creada")
+
+
 async def scheduler():
     """Background task to clean expired missions and warn users."""
     while True:


### PR DESCRIPTION
## Summary
- support admin IDs in config
- add `/createmission` command so admins can assign missions
- document latest changes and next step

## Testing
- `python -m py_compile bot/config.py bot/database.py bot/main.py`
- `black --check .` *(after formatting)*
- `pip install aiogram==3.0.0 -q` *(fails: build error)*

------
https://chatgpt.com/codex/tasks/task_e_685025b263f8832997ecb5889c03420d