### PR TITLE
Implement weekly missions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 8. Sistema de ranking de usuarios con comando /ranking
 9. Sistema de logros y medallas para usuarios
 10. Tienda para canjear puntos por recompensas
+11. Retos semanales automáticos para usuarios
 
 ##  Tarea
 Agregar retos semanales para usuarios
@@ -38,5 +39,5 @@ Una vez terminaba tu tarea y verificado que funciona y que responde  como deber�
 
 ## Tarea (este es un ejemplo, actualiza arriba, aquí no)
 
-(Agrega una descripción del próximo paso lógico en este tipo de proyectos) 
+Agregar estadísticas de actividad semanal y notificaciones en el canal.
 finalizas creando una nueva tarea con la instrucción "sigue las instruccioones de readme.md"

--- a/bot/main.py
+++ b/bot/main.py
@@ -4,6 +4,7 @@ from aiogram.filters import Command
 from aiogram.types import Message
 
 from typing import Optional
+from datetime import datetime, timedelta
 
 from .config import settings
 from .database import (
@@ -18,6 +19,7 @@ from .database import (
     get_missions_near_expiry,
     mark_warning_sent,
     assign_daily_missions,
+    assign_weekly_missions,
     get_top_users,
     award_achievement,
     get_user_achievements,
@@ -236,9 +238,25 @@ async def daily_mission_scheduler():
         await asyncio.sleep(3600)
 
 
+async def weekly_mission_scheduler():
+    """Assign weekly missions to all users once per week."""
+    last_week = datetime.utcnow().date() - timedelta(days=datetime.utcnow().weekday())
+    while True:
+        current_week = datetime.utcnow().date() - timedelta(days=datetime.utcnow().weekday())
+        if current_week != last_week:
+            assign_weekly_missions(
+                "Reto semanal: participa con 10 mensajes",
+                points=20,
+                goal=10,
+            )
+            last_week = current_week
+        await asyncio.sleep(3600)
+
+
 async def main():
     asyncio.create_task(scheduler())
     asyncio.create_task(daily_mission_scheduler())
+    asyncio.create_task(weekly_mission_scheduler())
     await dp.start_polling(bot)
 
 


### PR DESCRIPTION
## Summary
- add weekly mission assignment system
- schedule weekly mission creation in main bot
- document weekly mission feature and next task in README

## Testing
- `python -m py_compile bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685046131670832988d4e97c7c6c8cd0