### PR TITLE
Add weekly mission command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 9. Sistema de logros y medallas para usuarios
 10. Tienda para canjear puntos por recompensas
 11. Retos semanales automáticos para usuarios
+12. Comando /weekly para consultar el reto semanal asignado
 
 ##  Tarea
-Agregar retos semanales para usuarios
+Agregar estadísticas de actividad semanal y notificaciones en el canal
 
 Una vez terminaba tu tarea y verificado que funciona y que responde  como debería   procede a:
 -Actualizar el nombre de la tarea (en Codex) con algo que describa este paso

--- a/bot/database.py
+++ b/bot/database.py
@@ -273,6 +273,22 @@ def assign_weekly_missions(
         session.commit()
 
 
+def get_weekly_mission(user_id: int) -> Optional[Mission]:
+    """Return the active weekly mission for the given user."""
+    today = datetime.utcnow().date()
+    monday = today - timedelta(days=today.weekday())
+    start = datetime.combine(monday, datetime.min.time())
+    end = start + timedelta(days=7)
+    with get_session() as session:
+        statement = select(Mission).where(
+            Mission.user_id == user_id,
+            Mission.type == "weekly",
+            Mission.created_at >= start,
+            Mission.created_at < end,
+        )
+        return session.exec(statement).first()
+
+
 def award_achievement(user_id: int, name: str, description: str) -> Achievement:
     """Grant an achievement and update user badges."""
     achievement = Achievement(

--- a/bot/main.py
+++ b/bot/main.py
@@ -26,6 +26,7 @@ from .database import (
     get_rewards,
     redeem_reward,
     add_reward,
+    get_weekly_mission,
 )
 
 bot = Bot(token=settings.bot_token)
@@ -86,6 +87,21 @@ async def missions_list(message: Message):
     ]
     await message.answer(
         "\n".join(text_lines) + f"\nPuntos: {user.points} Nivel: {user.level}"
+    )
+
+
+@dp.message(Command("weekly"))
+async def weekly_mission(message: Message):
+    """Show the current weekly mission for the user."""
+    user_id = message.from_user.id
+    mission = get_weekly_mission(user_id)
+    if not mission:
+        await message.answer("No tienes un reto semanal asignado actualmente")
+        return
+    reward = calculate_reward(mission)
+    await message.answer(
+        f"Reto semanal: {mission.description}\n"
+        f"Progreso: {mission.progress}/{mission.goal} (+{reward} pts)"
     )
 
 


### PR DESCRIPTION
## Summary
- expose a helper to get weekly mission for a user
- add `/weekly` command to show weekly mission details
- document new command and next task in README

## Testing
- `python -m py_compile bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685049c830b88329a19b81ea878b93dc