### PR TITLE
Implement weekly activity rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 11. Retos semanales automáticos para usuarios
 12. Comando /weekly para consultar el reto semanal asignado
 13. Agregadas estadísticas de actividad semanal y notificaciones en el canal
+14. Recompensa automática a los usuarios más activos cada semana
 
 ##  Tarea
-Agregar estadísticas de actividad semanal y notificaciones en el canal.
-(en caso de que ya esté hecha está tarea, realiza el siguente paso lógico.
+Implementar recompensas automáticas para los usuarios con mayor actividad semanal.
+(en caso de que ya esté hecha esta tarea, realiza el siguiente paso lógico.
 
 Una vez terminaba tu tarea y verificado que funciona y que responde  como debería   procede a:
 -Actualizar el nombre de la tarea (en Codex) con algo que describa este paso
@@ -37,4 +38,4 @@ Estructura:
 (actualiza la estructura del proyecto en caso de que hayas creado archivos)
 Progreso:
 (en el número siguiente pon una descripción que se ajuste a lo que hiciste)
--Tarea: Instrucciones para desarrollar en siguente paso lógico para el desarrollo de un sistema como este 
+-Tarea: Implementar clasificación mensual de usuarios con recompensas automáticas

--- a/bot/main.py
+++ b/bot/main.py
@@ -30,6 +30,7 @@ from .database import (
     record_user_message,
     get_weekly_activity,
     get_user_weekly_stat,
+    reward_top_weekly_users,
 )
 
 bot = Bot(token=settings.bot_token)
@@ -304,6 +305,13 @@ async def weekly_summary_scheduler():
                 lines = [f"{idx+1}. {s.user_id} - {s.message_count}" for idx, s in enumerate(stats)]
                 text = "Resumen de actividad semanal:\n" + ("\n".join(lines) if lines else "Sin actividad")
                 await bot.send_message(settings.notify_channel_id, text)
+            bonus = 10
+            rewarded = reward_top_weekly_users(last_week, points=bonus)
+            for user in rewarded:
+                await bot.send_message(
+                    user.id,
+                    f"\u00a1Felicidades! Fuiste de los m\u00e1s activos y ganas {bonus} puntos extra",
+                )
             last_week = current_week
         await asyncio.sleep(3600)
 


### PR DESCRIPTION
## Summary
- reward top users each week and notify them
- update weekly summary scheduler accordingly
- document new feature and next tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68505857ce088329af638addc8476e96