### PR TITLE
Fix relative imports in main

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -6,8 +6,9 @@ from aiogram.types import Message
 from typing import Optional
 from datetime import datetime, timedelta
 
-from .config import settings
-from .database import (
+# Use absolute imports so the module can run as a script
+from bot.config import settings
+from bot.database import (
     get_or_create_user,
     reset_missions,
     assign_mission,


### PR DESCRIPTION
## Summary
- use absolute imports in `bot/main.py` so the script can run directly

## Testing
- `python -m py_compile bot/main.py bot/config.py bot/database.py`

------
https://chatgpt.com/codex/tasks/task_e_685061eb1d748329b36c5264960ff535