### PR TITLE
Fix import path for standalone execution

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1,4 +1,12 @@
 import asyncio
+from pathlib import Path
+import sys
+
+# Ensure project root is on sys.path when running the file directly
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 from aiogram.types import Message


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` when running `bot/main.py` directly

## Testing
- `python -m py_compile bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6850683d153c8329a8a1eff0dd2da4b3