### PR TITLE
Fix command filter

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -7,7 +7,7 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from aiogram import Bot, Dispatcher, types
+from aiogram import Bot, Dispatcher, types, F
 from aiogram.filters import Command
 from aiogram.types import Message
 
@@ -290,7 +290,7 @@ async def purchases_command(message: Message):
     await message.answer("Tus compras:\n" + "\n".join(lines))
 
 
-@dp.message(~Command())
+@dp.message(~F.text.startswith("/"))
 async def track_messages(message: Message):
     """Track user activity on every message."""
     if message.from_user and message.chat.type in {"private", "group", "supergroup"}:


### PR DESCRIPTION
## Summary
- replace invalid filter with `~F.text.startswith("/")`
- import `F`

## Testing
- `python -m py_compile bot/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68506b0594548329a8297ce4120d60ac