### PR TITLE
Add admin purchases lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 15. Comando /addreward para que administradores agreguen recompensas a la tienda
 16. Notificación en el canal cuando un usuario compra una recompensa
 17. Registro de compras en la base de datos y comando /purchases para consultarlas
+18. Consulta de compras de cualquier usuario con /purchases <id> para administradores
 
 ##  Tarea
-Permitir a los administradores consultar las compras de cualquier usuario.
+Agregar resumen mensual de compras para los administradores.
 
 Una vez terminaba tu tarea y verificado que funciona y que responde  como debería   procede a:
 -Actualizar el nombre de la tarea (en Codex) con algo que describa este paso


### PR DESCRIPTION
## Summary
- allow admins to pass a user id to /purchases command
- document the new feature in progress list and update next task

## Testing
- `python -m py_compile bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68506bec4f9c8329a8d05e6f1872ffc8