### PR TITLE
Add admin router skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 - bot/config.py carga de variables de entorno.
 - bot/database.py modelos y utilidades de base de datos con SQLModel.
 - bot/main.py punto de entrada del bot.
+- bot/admin/ router y comandos de administración.
 
 ## Progreso
 1. Instalé y generé la estructura básica del bot
@@ -31,9 +32,10 @@ Este proyecto contiene un bot de Telegram basado en Aiogram 3 que servirá Como 
 17. Registro de compras en la base de datos y comando /purchases para consultarlas
 18. Consulta de compras de cualquier usuario con /purchases <id> para administradores
 19. Resumen mensual de compras disponible para administradores
+20. Creada estructura básica de comandos de administración
 
 ##  Tarea
-crea la estructura básica de la administración
+organizar los comandos de administración en el nuevo router
 
 Una vez terminaba tu tarea y verificado que funciona y que responde  como debería   procede a:
 -Actualizar el nombre de la tarea (en Codex) con algo que describa este paso

--- a/bot/admin/__init__.py
+++ b/bot/admin/__init__.py
@@ -1,0 +1,15 @@
+from aiogram import Router
+from aiogram.filters import Command, BaseFilter
+from aiogram.types import Message
+
+from bot.config import settings
+
+router = Router()
+
+class AdminFilter(BaseFilter):
+    async def __call__(self, message: Message) -> bool:
+        return message.from_user and message.from_user.id in settings.admin_ids
+
+@router.message(Command("admin"), AdminFilter())
+async def admin_panel(message: Message) -> None:
+    await message.answer("Panel de administraci\u00f3n activo")

--- a/bot/main.py
+++ b/bot/main.py
@@ -43,9 +43,11 @@ from bot.database import (
     reward_top_weekly_users,
     get_monthly_purchase_summary,
 )
+from bot.admin import router as admin_router
 
 bot = Bot(token=settings.bot_token)
 dp = Dispatcher()
+dp.include_router(admin_router)
 
 
 @dp.message(Command("start"))


### PR DESCRIPTION
## Summary
- build initial admin router with command `/admin`
- include admin router in the bot dispatcher
- document new admin structure and progress step

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68509bca39948329a505d514e56bed72